### PR TITLE
Add rust serde_json tests

### DIFF
--- a/parsers/test_json-rust-serde_json/rj/.gitignore
+++ b/parsers/test_json-rust-serde_json/rj/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/parsers/test_json-rust-serde_json/rj/Cargo.toml
+++ b/parsers/test_json-rust-serde_json/rj/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rj"
+version = "0.1.0"
+authors = ["Nicolas Seriot <nicolas@seriot.ch>"]
+
+[dependencies]
+serde_json = "*"

--- a/parsers/test_json-rust-serde_json/rj/README
+++ b/parsers/test_json-rust-serde_json/rj/README
@@ -1,0 +1,2 @@
+cd /Users/nst/Projects/dropbox/JSON/test_json-rustc_serialize/rj; cargo build ;/Users/nst/Projects/dropbox/JSON/test_json-rustc_serialize/rj/target/debug/rj /Users/nst/Projects/dropbox/JSON/test_cases/n_177.json
+

--- a/parsers/test_json-rust-serde_json/rj/src/main.rs
+++ b/parsers/test_json-rust-serde_json/rj/src/main.rs
@@ -1,0 +1,30 @@
+extern crate serde_json;
+use std::fs::File;
+use std::io::Read;
+use std::env;
+
+fn main() {
+    println!("Hello, world!");
+
+    let args: Vec<_> = env::args().collect();
+    if args.len() != 2 {
+        println!("Usage: {} file.json", args[0]);
+	    std::process::exit(1);
+    }
+
+    let ref path = args[1];
+    let mut s = String::new();
+    let mut f = File::open(path).expect("Unable to open file");
+    //f.read_to_string(&mut s).expect("Unable to read string");
+    //println!("{}", s);
+
+    match f.read_to_string(&mut s) {
+        Err(_) => std::process::exit(1),
+        Ok(_) => println!("{}", s),
+    }
+
+    match serde_json::from_str::<serde_json::Value>(&s) {
+        Ok(_) => std::process::exit(0),
+        Err(_) => std::process::exit(1)
+    };
+}

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,7 +7,7 @@ import sys
 from os import listdir
 from time import strftime
 
-BASE_DIR = "/Users/nst/Projects/JSONTestSuite/"
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 PARSERS_DIR = os.path.join(BASE_DIR, "parsers")
 TEST_CASES_DIR_PATH = os.path.join(BASE_DIR, "test_parsing")
 LOGS_DIR_PATH = os.path.join(BASE_DIR, "results")

--- a/run_tests.py
+++ b/run_tests.py
@@ -172,6 +172,11 @@ programs = {
            "url":"https://doc.rust-lang.org/rustc-serialize/rustc_serialize/json/index.html",
            "commands":[os.path.join(PARSERS_DIR, "test_json-rustc_serialize/rj/target/debug/rj")]
        },
+   "Rust serde_json":
+       {
+           "url":"https://github.com/serde-rs/json",
+           "commands":[os.path.join(PARSERS_DIR, "test_json-rust-serde_json/rj/target/debug/rj")]
+       },
    "Java json-simple 1.1.1":
        {
            "url":"",


### PR DESCRIPTION
Thanks for writing this! I added support for the Rust library [serde_json](https://github.com/serde-rs/json) library. It's a bit more strict than the other rust parsers, and the failures we had are known ones. We can blow the stack with recursion, only support UTF-8, and up to 64 bit numbers. We reject nearly all of these ambiguous cases, but we'll need to look into where we should be a little more loose. Thanks!