### PR TITLE
Make Haskell less fragile

### DIFF
--- a/parsers/test_haskell-aeson/.gitignore
+++ b/parsers/test_haskell-aeson/.gitignore
@@ -1,1 +1,2 @@
 *.cabal
+.stack-work

--- a/parsers/test_haskell-aeson/testaeson
+++ b/parsers/test_haskell-aeson/testaeson
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eu
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+cd $DIR
+stack exec testaeson $@

--- a/run_tests.py
+++ b/run_tests.py
@@ -195,7 +195,7 @@ programs = {
    "Haskell Aeson 0.11.2.1":
        {
            "url":"https://github.com/bos/aeson",
-           "commands":[os.path.join(PARSERS_DIR, "test_haskell-aeson/.stack-work/install/x86_64-osx/lts-6.22/7.10.3/bin/testaeson")]
+           "commands":[os.path.join(PARSERS_DIR, "test_haskell-aeson/testaeson")]
        },
 }
 


### PR DESCRIPTION
The haskell test was pointing at a specific binary location. This is a fragile solution. I've changed this to use `stack exec` to leverage the build tool to build and/or execute the binary.