### PR TITLE
Haskell: add required "packages" field to build config

### DIFF
--- a/parsers/test_haskell-aeson/stack.yaml
+++ b/parsers/test_haskell-aeson/stack.yaml
@@ -1,1 +1,2 @@
 resolver: lts-6.22
+packages: [.]


### PR DESCRIPTION
I'm surprised stack doesn't bail outright. It does *something*, but it didn't actually build the package. :)