### PR TITLE
Sr/add ruby parsers

### DIFF
--- a/parsers/test_oj_compat.rb
+++ b/parsers/test_oj_compat.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require 'oj'
+
+f = ARGV[0]
+
+o = nil
+
+Oj.default_options = { :mode => :compat }
+
+begin
+    puts(f)
+    json = File.read(f)
+    o = Oj.load( json )
+    p o
+    
+    if o == nil
+        exit 1
+    else
+        exit 0
+    end
+rescue JSON::ParserError => e
+    puts(e)
+    exit 1
+end

--- a/parsers/test_oj_strict.rb
+++ b/parsers/test_oj_strict.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require 'oj'
+
+f = ARGV[0]
+
+o = nil
+
+Oj.default_options = { :mode => :strict }
+
+begin
+    puts(f)
+    json = File.read(f)
+    o = Oj.load( json )
+    p o
+    
+    if o == nil
+        exit 1
+    else
+        exit 0
+    end
+rescue JSON::ParserError => e
+    puts(e)
+    exit 1
+end

--- a/parsers/test_yajl.rb
+++ b/parsers/test_yajl.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require 'yajl'
+
+f = ARGV[0]
+
+o = nil
+
+begin
+    puts(f)
+    json = File.read(f)
+    parser = Yajl::Parser.new
+    o = parser.parse( json )
+    p o
+    
+    if o == nil
+        exit 1
+    else
+        exit 0
+    end
+rescue JSON::ParserError => e
+    puts(e)
+    exit 1
+end

--- a/run_tests.py
+++ b/run_tests.py
@@ -76,6 +76,21 @@ programs = {
            "url":"",
            "commands":["/usr/bin/env", "ruby", os.path.join(PARSERS_DIR, "test_json_re.rb")]
        },
+   "Ruby Yajl":
+       {
+           "url":"",
+           "commands":["/usr/bin/env", "ruby", os.path.join(PARSERS_DIR, "test_yajl.rb")]
+       },
+   "Ruby Oj (strict mode)":
+       {
+           "url":"",
+           "commands":["/usr/bin/env", "ruby", os.path.join(PARSERS_DIR, "test_oj_strict.rb")]
+       },
+   "Ruby Oj (compat mode)":
+       {
+           "url":"",
+           "commands":["/usr/bin/env", "ruby", os.path.join(PARSERS_DIR, "test_oj_compat.rb")]
+       },
    "Crystal":
        {
            "url":"https://github.com/crystal-lang/crystal",

--- a/run_tests.py
+++ b/run_tests.py
@@ -69,12 +69,12 @@ programs = {
    "Ruby":
        {
            "url":"",
-           "commands":["/usr/bin/ruby", os.path.join(PARSERS_DIR, "test_json.rb")]
+           "commands":["/usr/bin/env", "ruby", os.path.join(PARSERS_DIR, "test_json.rb")]
        },
    "Ruby regex":
        {
            "url":"",
-           "commands":["/usr/bin/ruby", os.path.join(PARSERS_DIR, "test_json_re.rb")]
+           "commands":["/usr/bin/env", "ruby", os.path.join(PARSERS_DIR, "test_json_re.rb")]
        },
    "Crystal":
        {


### PR DESCRIPTION
This PR incorporates two changes:
- Use "/usr/bin/env ruby" to find the ruby interpreter; otherwise ruby interpreters provided with rvm or another ruby switcher cannot be found
- Add tests for the Yajl ruby parser (use `gem install yajl` before testing)
- Add tests for the Oj ruby parser (use `gem install oj` before testing), for strict and compat mode