### PR TITLE
add xidel

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -71,6 +71,11 @@ programs = {
            "url":"",
            "commands":[os.path.join(PARSERS_DIR, "test_fpc/test_json")]
        },
+   "Xidel Internet Tools":
+       {
+           "url":"http://www.videlibri.de/xidel.html",
+           "commands":["/usr/bin/env", "xidel", "--input-format=json-strict", "-e=."]
+       },
    "Lua JSON 20160916.19":
        {
            "url":"http://regex.info/blog/lua/json",


### PR DESCRIPTION
This adds Xidel / Internet Tools.

There are actually two projects. "Internet Tools" a web-scraping library for Free Pascal, and "Xidel" a command line wrapper around it, as a few people do not develop with Free Pascal.

I have added the `--input-format json-strict` option to Xidel 0.9.6 just to pass more of your tests. The default option `--input-format json` accepts invalid JSON purposefully. 

I wrote the parser and data structures myself, but the *tokenizer* is the default tokenizer from Free Pascal's fcl-json, so the test results change depending on the fpc version it is compiled with. The release on the Xidel homepage is compiled with fpc 3.0.0, which gives worse results than fpc 3.1.1/trunk, because the tokenizer/parser of fpc 3.1.1 has an option to switch between strict and non strict parsing, while 3.0.0 always parses non-strict.  This also matters for the "Free Pascal fcl-json" parser in parsers/test_fpc/test_json, because that  uses the non-strict JSON parser from 3.0.0. If test_fpc/test_json was compiled with 3.1.1 and the new option, fcl-json would perform better.