### PR TITLE
Add Postgres JSONB test

### DIFF
--- a/parsers/test_postgres/test_postgres.py
+++ b/parsers/test_postgres/test_postgres.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+import sys
+
+with open(sys.argv[1], 'r') as f:
+    json = f.read()
+
+import psycopg2
+import psycopg2.errorcodes
+
+conn = psycopg2.connect("")
+cur = conn.cursor()
+try:
+    cur.execute("SELECT %s::jsonb;", (json,))
+    result = cur.fetchone()
+    exit(0) # allegedly valid json PASS
+except psycopg2.Error as e:
+    if (e.pgcode[:2] == CLASS_INTERNAL_ERROR):
+        print e.pgerror
+        exit(2) # unexpected error -- CRASH
+    else:
+        exit(1) # normal error -- FAIL
+
+    # expected errors are: 
+    #
+    # INVALID_TEXT_REPRESENTATION (invalid json)
+    # CHARACTER_NOT_IN_REPERTOIRE (invalid unicode)
+    # UNTRANSLATABLE_CHARACTER (nul unicode code point)
+    # STATEMENT_TOO_COMPLEX (nested too deep)

--- a/run_tests.py
+++ b/run_tests.py
@@ -346,6 +346,11 @@ programs = {
            "url":"http://nim-lang.org",
             "commands":[ os.path.join( PARSERS_DIR, "test_nim/test_json") ]
         },
+    "Postgres":
+        {
+            "url":"",
+            "commands":["/usr/bin/python", os.path.join(PARSERS_DIR, "test_postgres/test_postgres.py")]
+        },
 }
 
 def run_tests(restrict_to_path=None, restrict_to_program=None):


### PR DESCRIPTION
This just connects to whatever Postgres server is handy which could be an issue if testing multiple versions is desirable however it's hard to do much better and this is convenient.

It treats any Postgres error as a parser failure (except for internal errors). In practice Postgres doesn't distinguish well between "parser errors" and other errors. Nesting too deep and unsupported unicode encodings both show up as generic errors, not parser errors.

It does treat "internal" Postgres errors as crashes. It doesn't try to detect actual server crashes which would confuse all subsequent tests as they would result in connection errors. Thankfully neither of these occur.