### PR TITLE
Add python-cjson

### DIFF
--- a/parsers/test_cjson.py
+++ b/parsers/test_cjson.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import cjson as json
+import sys
+
+#def f_parse_constant(o):
+#    raise BaseException
+
+def parse_file(path):
+
+    with open(path, 'r') as f:
+
+        data = f.read()
+
+        try:
+            o = json.decode(data)
+
+        except Exception as e:
+            sys.exit(1)
+
+if __name__ == "__main__":
+
+    path = sys.argv[1]
+    parse_file(path)
+
+    sys.exit(0)
+

--- a/run_tests.py
+++ b/run_tests.py
@@ -136,6 +136,11 @@ programs = {
            "url":"",
            "commands":["/usr/bin/env", "python3.5", os.path.join(PARSERS_DIR, "test_json.py")]
        },
+   "Python cjson 1.10": # pip install cjson
+       {
+           "url":"https://pypi.python.org/pypi/python-cjson",
+           "commands":["/usr/bin/python", os.path.join(PARSERS_DIR, "test_cjson.py")]
+       },
    "Python ujson 1.35": # pip install ujson
        {
            "url":"https://pypi.python.org/pypi/ujson",


### PR DESCRIPTION
[python-cjson](https://github.com/AGProjects/python-cjson) is packaged for several distros and included in anyjson's list of parsers (albeit at the bottom), so I figured to test it. The test catches two crashes, which I'll report upstream.