### PR TITLE
Add python demjson parser.

### DIFF
--- a/parsers/test_demjson.py
+++ b/parsers/test_demjson.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import demjson as json
+import sys
+
+def parse_file_intrinsically(path):
+    try:
+        o = json.decode_file(path, strict=True)
+
+    except Exception as e:
+        raise
+        sys.exit(1)
+    return
+
+def parse_file(path):
+    with open(path, 'rb') as f:
+
+        data = f.read()
+
+        try:
+            o = json.decode(data, strict=True)
+
+        except Exception as e:
+            raise
+            sys.exit(1)
+
+if __name__ == "__main__":
+
+    path = sys.argv[1]
+    parse_file_intrinsically(path)
+
+    sys.exit(0)
+

--- a/run_tests.py
+++ b/run_tests.py
@@ -151,6 +151,21 @@ programs = {
            "url":"https://pypi.python.org/pypi/simplejson",
            "commands":["/usr/bin/python", os.path.join(PARSERS_DIR, "test_simplejson.py")]
        },
+   "Python demjson 2.2.4": # pip install demjson
+       {
+           "url":"https://pypi.python.org/pypi/demjson",
+           "commands":["/usr/bin/python", os.path.join(PARSERS_DIR, "test_demjson.py")]
+       },
+   "Python demjson 2.2.4 (py3)": # pip install demjson
+       {
+           "url":"https://pypi.python.org/pypi/demjson",
+           "commands":["/usr/bin/env", "python3.5", os.path.join(PARSERS_DIR, "test_demjson.py")]
+       },
+   "Python demjson 2.2.4 (jsonlint)": # pip install demjson
+       {
+           "url":"https://pypi.python.org/pypi/demjson",
+           "commands":["/usr/bin/env", "jsonlint", "--quiet", "--strict", "--allow=non-portable,duplicate-keys,zero-byte"]
+       },
    "Perl Cpanel::JSON::XS":
        {
            "url":"http://search.cpan.org/dist/Cpanel-JSON-XS/",


### PR DESCRIPTION
demjson works under both Python 2 and Python 3, as well as including it's own stand-alone command line tool "jsonlint".

It is worth noting that demjson is specifically designed as a tool to find problems with JSON documents, whether they are non-conforming or if they may contain non-portable data that can cause some JSON parsers to fail, so it is a good complement to your project testing JSON files rather than parsers.

demjson is a standard package in many Linux distributions (Fedora, Ubuntu, etc.) and if you install it with the package manager you should also get a command line utility "jsonlint" which will output very detailed error and warning messages about any JSON file..  It is interesting to run it against your test_parsing/*.json files.

More information is at http://deron.meranda.us/python/demjson/