### PR TITLE
Force UTF-8 encoding for the report file

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -685,7 +685,7 @@ def generate_report(report_path, keep_only_first_result_in_set = False):
 
     tests_with_same_results = f_tests_with_same_results(libs, status_for_lib_for_file)
 
-    with open(report_path, 'w') as f:
+    with open(report_path, 'w', encoding='utf-8') as f:
 
         f.write("""<!DOCTYPE html>
 


### PR DESCRIPTION
I know that basically all Linux flavors are using UTF-8 as their system encoding, but as I tried to use this script under Windows, this was clearly not the case (CP1252 instead)
This pull request makes sure the generated reports are using the UTF-8 encoding.