### PR TITLE
Add libfyaml JSON mode parser

### DIFF
--- a/parsers/test_libfyaml.sh
+++ b/parsers/test_libfyaml.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+fy-testsuite --streaming --json=force $1 >/dev/null 2>/dev/null
+if [ $? -ne 0 ]; then
+	exit 1
+fi
+exit 0

--- a/run_tests.py
+++ b/run_tests.py
@@ -480,6 +480,11 @@ programs = {
        {
            "url":"https://github.com/nlohmann/json",
            "commands":[os.path.join(PARSERS_DIR, "test_nlohmann_json_20190718/bin/test_nlohmann_json")]
+       },
+   "libfyaml":
+       {
+           "url":"https://github.com/pantoniou/libfyaml",
+           "commands":[os.path.join(PARSERS_DIR, "test_libfyaml.sh")]
        }
 }
 


### PR DESCRIPTION
Add libfyaml's JSON mode parser - no binary required; just the
built-in testsuite harness of libfyaml is enough.

Note that all the tests pass, besides the implementation defined ones.

Signed-off-by: Pantelis Antoniou <pantelis.antoniou@konsulko.com>