### PR TITLE
Add RubyLane's tcl parser

### DIFF
--- a/parsers/test_rl_json/run_rl_json.tcl
+++ b/parsers/test_rl_json/run_rl_json.tcl
@@ -1,0 +1,8 @@
+package require rl_json
+try {
+  set s [read stdin]
+  ::rl_json::json parse $s
+} on error {e o} {
+    exit 1
+}
+exit 0

--- a/parsers/test_rl_json/tclsh
+++ b/parsers/test_rl_json/tclsh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tclsh $*

--- a/run_tests.py
+++ b/run_tests.py
@@ -20,6 +20,12 @@ LOG_FILE_PATH = os.path.join(LOGS_DIR_PATH, LOG_FILENAME)
 INVALID_BINARY_FORMAT = 8
 
 programs = {
+    "RubyLane":
+        {
+            "url":"https://github.com/RubyLane/rl_json",
+            "commands":[os.path.join(PARSERS_DIR, "test_rl_json/tclsh"), os.path.join(PARSERS_DIR, "test_rl_json/run_rl_json.tcl")],
+            "use_stdin":True
+        },
     "Bash JSON.sh 2016-08-12":
         {
             "url":"https://github.com/dominictarr/JSON.sh",


### PR DESCRIPTION
The RubyLane tcl parser is based on a internal C parser.
This used to be yajl C based. Therefore, it's time to add it to this test
suite. For a single file parser it does fairly well.