### PR TITLE
Improve the test runner

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -502,6 +502,14 @@ def run_tests(restrict_to_path=None, restrict_to_program=None):
 
         url = d["url"]
         commands = d["commands"]
+        setup = d.get("setup")
+        if setup != None:
+            print("--", " ".join(setup))
+            try:
+                subprocess.call(setup)
+            except Exception as e:
+                print("-- skip", e)
+                continue
 
         for root, dirs, files in os.walk(TEST_CASES_DIR_PATH):
             json_files = (f for f in files if f.endswith(".json"))

--- a/run_tests.py
+++ b/run_tests.py
@@ -503,10 +503,6 @@ def run_tests(restrict_to_path=None, restrict_to_program=None):
         url = d["url"]
         commands = d["commands"]
 
-        if not os.path.exists(commands[0]):
-            print("-- skip non-existing", commands[0])
-            continue
-
         for root, dirs, files in os.walk(TEST_CASES_DIR_PATH):
             json_files = (f for f in files if f.endswith(".json"))
             for filename in json_files:
@@ -545,10 +541,13 @@ def run_tests(restrict_to_path=None, restrict_to_program=None):
                     log_file.write("%s\n" % s)
                     print("RESULT:", result)
                     continue
+                except FileNotFoundError as e:
+                    print("-- skip non-existing", e.filename)
+                    break
                 except OSError as e:
                     if e.errno == INVALID_BINARY_FORMAT:
                         print("-- skip invalid-binary", commands[0])
-                        continue
+                        break
                     raise e
 
                 if use_stdin:


### PR DESCRIPTION
1. Catch FileNotFoundError instead of checking if a command can be run with `os.path.exists(commands[0])`. This will allow to write commands more naturally, without having to hardcode absolute paths or the `/usr/bin/env` trick.

Before this commit:
```
 "commands":["/usr/local/bin/lua", os.path.join…
```

After this commit:
```
 "commands":["lua", os.path.join…
```

Also, when an invalid binary is detected, don't try to run all the tests but stop at the first one.

2. Add an optional `setup` command that is run once before running all the tests.

This can be useful to run a compilation step so that we don't need to commit huge binaries to the repository. For cross platform environment such as .NET this is even more important because we don't want to commit a (huge) ELF or Mach-O binary to be able to run the tests in a cross-platform way.

Update taking advantage of this new feature for *Json.NET* and *.NET System.Text.Json* runner will come after this pull request is merged. ;-)