### PR TITLE
Add jsoncgx

### DIFF
--- a/parsers/test_jsoncgx.py
+++ b/parsers/test_jsoncgx.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import sys
+import jsoncgx
+
+if __name__ == "__main__":
+    allow_comments = sys.argv[1] == "on"
+    path = sys.argv[2]
+
+    try:
+        jsoncgx.loadf(path, allow_comments)
+    except Exception:
+        sys.exit(1)
+    sys.exit(0)

--- a/run_tests.py
+++ b/run_tests.py
@@ -192,6 +192,16 @@ programs = {
            "url":"https://pypi.python.org/pypi/demjson",
            "commands":["/usr/bin/env", "jsonlint", "--quiet", "--strict", "--allow=non-portable,duplicate-keys,zero-byte"]
        },
+   "Python jsoncgx (allow_comments: off)": # pip install jsoncgx
+       {
+           "url":"https://pypi.org/project/jsoncgx/",
+           "commands":["/usr/bin/env", "python3", os.path.join(PARSERS_DIR, "test_jsoncgx.py"), "off"]
+       },
+   "Python jsoncgx (allow_comments: on)": # pip install jsoncgx
+       {
+           "url":"https://pypi.org/project/jsoncgx/",
+           "commands":["/usr/bin/env", "python3", os.path.join(PARSERS_DIR, "test_jsoncgx.py"), "on"]
+       },
    "Perl Cpanel::JSON::XS":
        {
            "url":"https://metacpan.org/pod/Cpanel::JSON::XS",


### PR DESCRIPTION
Add `jsoncgx`, a JSONC parser in/for Python 3 I developed for my specific needs:
* https://github.com/cigix/jsoncgx
* https://pypi.org/project/jsoncgx

This test suite was instrumental in helping me test and improve my parser, and I thank you for it.