### PR TITLE
Update test_json.rb

### DIFF
--- a/parsers/test_json.rb
+++ b/parsers/test_json.rb
@@ -4,19 +4,11 @@ require 'json'
 
 f = ARGV[0]
 
-o = nil
-
 begin
     puts(f)
     json = File.read(f)
-    o = JSON.parse(json, {:quirks_mode => true})
-    p o
-    
-    if o == nil
-        exit 1
-    else
-        exit 0
-    end
+    JSON.parse(json)
+    exit 0
 rescue JSON::ParserError => e
     puts(e)
     exit 1


### PR DESCRIPTION
- The `parse` method never return `nil` on error, it always raise an exception. This is causing the standalone `null` test case to be considered failed, even thought it parses correctly.
- `quirks_mode` hasn't been a valid option for a very long time.